### PR TITLE
use auth header instead of query for github checks

### DIFF
--- a/src/Squirrel/UpdateManager.Factory.cs
+++ b/src/Squirrel/UpdateManager.Factory.cs
@@ -45,9 +45,6 @@ namespace Squirrel
             var releasesApiBuilder = new StringBuilder("repos")
                 .Append(repoUri.AbsolutePath)
                 .Append("/releases");
-
-            if (!string.IsNullOrWhiteSpace(accessToken))
-                releasesApiBuilder.Append("?access_token=").Append(accessToken);
             
             Uri baseAddress;
 
@@ -66,6 +63,10 @@ namespace Squirrel
 
             using (var client = new HttpClient() { BaseAddress = baseAddress }) {
                 client.DefaultRequestHeaders.UserAgent.Add(userAgent);
+
+                if (!string.IsNullOrWhiteSpace(accessToken))
+                    client.DefaultRequestHeaders.Add("Authorization", $"token {accessToken}");
+
                 var response = await client.GetAsync(releasesApiBuilder.ToString());
                 response.EnsureSuccessStatusCode();
 


### PR DESCRIPTION
In November GitHub is disabling [authorization via query](https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/#changes-to-make). This PR _should_ resolve this by using token based auth headers instead.

This was the PR I meant to open but managed to open the wrong one prior to this :man_facepalming: